### PR TITLE
allow 1 covariate

### DIFF
--- a/R/Main_SSD.R
+++ b/R/Main_SSD.R
@@ -46,7 +46,7 @@ Read_Plink_FAM_Cov<-function(Filename, File_Cov, Is.binary=TRUE, flag1=0, cov_he
 	Cov.Obj<-read.table(File_Cov, header=cov_header)
 	ncov<-dim(Cov.Obj)[2]
 	
-	if(ncov <= 3){
+	if(ncov <= 2){
 		msg<-sprintf("Error: Cov file only has <= 2 columns!\n")
 		stop(msg)
 	}


### PR DESCRIPTION
Hi Shawn, I'm not sure whether you've fully migrated to GitHub yet, but I thought I'd add a simple pull request and welcome SKAT here!

This pull request contains a trivial change to address this bug: [Bug in Version 1.2.1 with 1 covariate in Read_Plink_FAM_Cov](https://groups.google.com/forum/#!topic/skat_slee/DF7QD2t_GTo).
