### PR TITLE
Update Binary_MAIN_Robust.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SKAT
 Type: Package 
 Title: SNP-Set (Sequence) Kernel Association Test
-Version: 2.2.0
-Date: 2020-12-23
+Version: 2.2.1
+Date: 2021-04-22
 Author: Seunggeun (Shawn) Lee and Zhangchen Zhao, with contributions from Larisa Miropolsky and Michael Wu
 Maintainer: Seunggeun (Shawn) Lee <lee7801@snu.ac.kr>  
 Description: Functions for kernel-regression-based association tests including Burden test, SKAT and SKAT-O. These methods aggregate individual SNP score statistics in a SNP set and efficiently compute SNP-set level p-values.

--- a/R/Binary_MAIN_Robust.R
+++ b/R/Binary_MAIN_Robust.R
@@ -305,7 +305,7 @@ SKATBinary_Robust.SSD.All = function(SSD.INFO, obj, ...,obj.SNPWeight=NULL){
       warning(msg,call.=FALSE)
       
     } else {
-      if (min(re$mac,0,na.rm=T)>=1){
+      if (min(try1$mac,0,na.rm=T)>=1){
         re =try1
         OUT.Pvalue[i]<-re$p.value
         OUT.Marker[i]<-re$param$n.marker

--- a/R/Binary_MAIN_Robust.R
+++ b/R/Binary_MAIN_Robust.R
@@ -305,18 +305,19 @@ SKATBinary_Robust.SSD.All = function(SSD.INFO, obj, ...,obj.SNPWeight=NULL){
       warning(msg,call.=FALSE)
       
     } else {
-      re =try1
-      OUT.Pvalue[i]<-re$p.value
-      OUT.Marker[i]<-re$param$n.marker
-      OUT.Marker.Test[i]<-re$param$n.marker.test
-      OUT.MAC[i]<-re$mac
-      OUT.Q[i]<-re$Q
+      if (min(re$mac,0,na.rm=T)>=1){
+        re =try1
+        OUT.Pvalue[i]<-re$p.value
+        OUT.Marker[i]<-re$param$n.marker
+        OUT.Marker.Test[i]<-re$param$n.marker.test
+        OUT.MAC[i]<-re$mac
+        OUT.Q[i]<-re$Q
       #if(Is.Resampling){
       #  OUT.Pvalue.Resampling[i,]<-re$p.value.resampling
       #}
-      SetID<-SSD.INFO$SetInfo$SetID[i]
-      OUT.snp.mac[[SetID]]<-re$test.snp.mac
-      
+        SetID<-SSD.INFO$SetInfo$SetID[i]
+        OUT.snp.mac[[SetID]]<-re$test.snp.mac
+      }
     }
     #if(floor(i/100)*100 == i){
     #	cat("\r", i, "/", N.Set, "were done");


### PR DESCRIPTION
Try to solve a bug in SSD.ALL. The error message is "OUT.MAC[i]<-re$mac: replacement has length zero".