### PR TITLE
Ensure SNP ID assignment for single variant case in SingleSNP_INFO

### DIFF
--- a/R/MAIN.R
+++ b/R/MAIN.R
@@ -404,14 +404,20 @@ SKAT_Check_Method<-function(method,r.corr, n=NULL, m=NULL){
 
 }
 
-SingleSNP_INFO<-function(Z){
+SingleSNP_INFO <- function(Z) {
+  snplist <- colSums(Z)
   
-
-  snplist<-colSums(Z)
-  names(snplist)<-colnames(Z)
-
+  # Assign SNP IDs as the names of snplist
+  if (is.null(dim(Z))) {  # This is a new conditional check to see if Z is a vector
+    # When Z has only one column, it's treated as a vector and doesn't have column names
+    # In this case, the SNP ID should be the name of Z itself
+    names(snplist) <- names(Z)  # Assigning the name of Z to snplist when Z is a vector
+  } else {
+    # In general, SNP IDs are the column names of Z
+    names(snplist) <- colnames(Z)  # This is the original assignment from the previous version
+  }
+  
   return(snplist)
-  
 }
 
 


### PR DESCRIPTION
MAIN.R line 407-421: The function SingleSNP_INFO computes minor allele counts for each SNP and assigns SNP IDs as the names of this numeric vector. However, when the Z matrix has only one column (i.e., there's only one SNP), it's treated as a vector and does not have column names. In this case, the SNP ID should be the name of Z itself. This pull request modifies SingleSNP_INFO to handle this edge case and correctly assign the SNP ID even when there's only one SNP in the Z matrix.

For instance, consider the following examples:

When the Z matrix has two variants, SNP IDs are correctly returned:

> SKAT(Z, obj, method="SKATO")$test.snp.mac
chr21:30166452_G/A chr21:39792006_A/G 
                 1                  1 
However, when the Z matrix has only one variant, the SNP ID is not returned and instead the output is a single numeric value:

> SKAT(Z, obj, method="SKATO")$test.snp.mac
[1] 1

The updated SingleSNP_INFO function addresses this issue by ensuring that SNP IDs are always returned, irrespective of the number of variants in the Z matrix.