### PR TITLE
Change order of header file inclusions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SKAT
 Type: Package 
 Title: SNP-Set (Sequence) Kernel Association Test
-Version: 2.2.5
-Date: 2023-01-12
+Version: 2.2.6
+Date: 2023-11-15
 Author: Seunggeun (Shawn) Lee and Zhangchen Zhao, with contributions from Larisa Miropolsky and Michael Wu
 Maintainer: Seunggeun (Shawn) Lee <lee7801@snu.ac.kr>  
 Description: Functions for kernel-regression-based association tests including Burden test, SKAT and SKAT-O. These methods aggregate individual SNP score statistics in a SNP set and efficiently compute SNP-set level p-values.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: SKAT
-Type: Package 
+Type: Package
 Title: SNP-Set (Sequence) Kernel Association Test
-Version: 2.2.6
-Date: 2023-11-15
+Version: 2.3.2
+Date: 2025-08-06
 Author: Seunggeun (Shawn) Lee and Zhangchen Zhao, with contributions from Larisa Miropolsky and Michael Wu
-Maintainer: Seunggeun (Shawn) Lee <lee7801@snu.ac.kr>  
+Maintainer: Seunggeun (Shawn) Lee <lee7801@snu.ac.kr>
 Description: Functions for kernel-regression-based association tests including Burden test, SKAT and SKAT-O. These methods aggregate individual SNP score statistics in a SNP set and efficiently compute SNP-set level p-values.
-License: GPL(>=2)
+License: GPL (>= 2)
 Depends: R (>= 2.13.0), Matrix, SPAtest, RSpectra

--- a/src/Binary_Permu_SKAT.cpp
+++ b/src/Binary_Permu_SKAT.cpp
@@ -1,14 +1,14 @@
-#ifndef _STAND_ALONE_
-
-    #include <R.h>
-    #include <Rmath.h>
-    
-#endif
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "Binary_global.h"
 #include "Binary_Permu_SKAT.h"
+
+#ifndef _STAND_ALONE_
+    #include <R.h>
+    #include <Rmath.h>
+#endif
 
 /*********************************************************************
 

--- a/src/Binary_resampling.cpp
+++ b/src/Binary_resampling.cpp
@@ -1,12 +1,11 @@
-#ifndef _STAND_ALONE_
-
-    #include <R.h>
-    #include <Rmath.h>
-    
-#endif
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _STAND_ALONE_
+    #include <R.h>
+    #include <Rmath.h>
+#endif
 
 /*********************************************************************
 

--- a/src/kernel_func.cpp
+++ b/src/kernel_func.cpp
@@ -1,6 +1,6 @@
+#include <math.h>
 #include <R.h>
 #include <Rmath.h>
-#include <math.h>
 /********************************************************
 *
 *	Kernel function ver 0.2


### PR DESCRIPTION
This pull request fixes #19.

Fortunately the solution was quite simple: I realized that the problematic C++ files have the line `#include <Rmath.h>` before the line `#include <math.h>`. While newer versions of gcc seem to be unaffected by the order of these `#include` statements, older versions (such as the one on my HPC cluster) will not build the files unless `math.h` is imported first. After switching the order such that `#include <math.h>` comes before `#include <Rmath.h>`, I was able to successfully install SKAT on my system.