### PR TITLE
Change to array indicies to prevent overflow.

### DIFF
--- a/R/MAIN.R
+++ b/R/MAIN.R
@@ -191,8 +191,8 @@ SKAT_MAIN_Check_Z<-function(Z, n, id_include, SetID, weights, weights.beta, impu
 	##############################################
 	# Check Missing 
 
-	IDX_MISS<-union(which(is.na(Z)),which(Z == 9))
-	if(length(IDX_MISS) > 0){
+	IDX_MISS<-rbind(which(is.na(Z), arr.ind = TRUE), which(Z == 9, arr.ind = TRUE))
+	if(nrow(IDX_MISS) > 0){
 		Z[IDX_MISS]<-NA
 	} 
 


### PR DESCRIPTION
Hi

This is a small contribution which is a fix to a problem I ran into.

I had an issue with the SKAT package on TTN with 500K rows and 10K columns. The index returned from the which function can exceed the maximum length of an underlying C array, resulting in an overflow. Using array indices fixes this problem.

Best regards,
Guðmundur Einarsson

